### PR TITLE
Remove arg from scale test in map exercise

### DIFF
--- a/lectures/05_functions_methods/25_map_helper_method/coding_exercise/README.md
+++ b/lectures/05_functions_methods/25_map_helper_method/coding_exercise/README.md
@@ -9,7 +9,7 @@ let lengths = [3, 7, 5];
 ```
 Now, Lewis and his best friend, Clark, want to know how long these paths are in real life. Luckily, they know that an inch on the map equals 8 miles in real life.
 
-Fix the scale function to return a new array with the values that Lewis and Clark want. Use a map helper method, and the 'multiple' parameter to do so.
+Fix the scale function to return a new array with the values that Lewis and Clark want. Use a map helper method, and the 'multiple' variable to do so.
 
 
 ###[Student File](./student.js)

--- a/lectures/05_functions_methods/25_map_helper_method/coding_exercise/evaluate.js
+++ b/lectures/05_functions_methods/25_map_helper_method/coding_exercise/evaluate.js
@@ -1,5 +1,5 @@
-describe('scale(8)', function() {
+describe('scale()', function() {
   it('should throw if the wrong result returns', function() {
-    expect(scale(8)).toEqual([24, 56, 40]);
+    expect(scale()).toEqual([24, 56, 40]);
   });
 });

--- a/lectures/05_functions_methods/25_map_helper_method/coding_exercise/solution.js
+++ b/lectures/05_functions_methods/25_map_helper_method/coding_exercise/solution.js
@@ -1,6 +1,6 @@
 let lengths = [3, 7, 5];
 let multiple = 8;
 
-const scale = (multiple) => {
+const scale = () => {
   return lengths.map(element => element * multiple);
 };

--- a/lectures/05_functions_methods/25_map_helper_method/coding_exercise/student.js
+++ b/lectures/05_functions_methods/25_map_helper_method/coding_exercise/student.js
@@ -1,6 +1,6 @@
 let lengths = [3, 7, 5];
 let multiple = 8;
 
-const scale = (multiple) => {
+const scale = () => {
   return lengths // TODO fill out the rest;
 };


### PR DESCRIPTION
I noticed during the quiz that the `let multiple` on line 2 wasn't doing anything. I figure it would be better that it is used so the quiz is a bit less confusing.